### PR TITLE
Fix test referencing old class path location

### DIFF
--- a/app/src/test/java/com/akseltorgard/devcalc/CalculatorTestCalculations.java
+++ b/app/src/test/java/com/akseltorgard/devcalc/CalculatorTestCalculations.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 
 import static com.akseltorgard.devcalc.Base.HEX;
 import static org.junit.Assert.assertEquals;
-import static com.akseltorgard.devcalc.Operators.BinaryOperator.*;
-import static com.akseltorgard.devcalc.Operators.UnaryOperator.*;
+import static com.akseltorgard.devcalc.operator.BinaryOperator.*;
+import static com.akseltorgard.devcalc.operator.UnaryOperator.*;
 
 public class CalculatorTestCalculations {
 


### PR DESCRIPTION
After moving the operator classes to their own package, the import reference in the test classes were not updated to reflect this change.